### PR TITLE
ignore hash differences

### DIFF
--- a/test/error-messages-cases/nonimported-module/expected
+++ b/test/error-messages-cases/nonimported-module/expected
@@ -1,2 +1,2 @@
 # FIXME: how to catch this error message and replace it with a nicer one?
-    attempting to use module ‘nonimported-module-0.0.0-1finyOzQnsgIioWcIf3KAR:NonimportedModule.ZRewriteRules’ (src/NonimportedModule/ZRewriteRules.hs) which is not loaded
+    attempting to use module ‘nonimported-module-0.0.0-<hash>:NonimportedModule.ZRewriteRules’ (src/NonimportedModule/ZRewriteRules.hs) which is not loaded

--- a/test/error-messages/Test.hs
+++ b/test/error-messages/Test.hs
@@ -116,8 +116,17 @@ main = do
                                  $ t
                               else t
 
+                -- "package-0.0.0-1finyOzQnsgIioWcIf3KAR:Module" -> "package-0.0.0-<hash>:Module"
+                cleanHashes :: Text -> Text
+                cleanHashes t = if "0.0.0-" `Text.isInfixOf` t
+                                then let (pre, hashPost) = Text.breakOn "0.0.0-" t
+                                         post = Text.dropWhile (/= ':') hashPost
+                                     in pre <> "0.0.0-<hash>" <> cleanHashes post
+                                else t
+
                 actualLines :: [Text]
                 actualLines = List.mapMaybe stripCasePrefix
+                            . fmap cleanHashes
                             . fmap cleanLine
                             . Text.lines
                             $ actualOutput


### PR DESCRIPTION
consider error messages the same if the only difference is the generated hash after a package name and version.

Fixes #18 