### PR TITLE
proper error locations in error messages

### DIFF
--- a/src/TypeLevel/Rewrite.hs
+++ b/src/TypeLevel/Rewrite.hs
@@ -153,7 +153,7 @@ solve rules givens _ wanteds = do
         let typeTerms = fmap toTypeTerm types
         let predType = fromDecomposeConstraint types
 
-        for_ (applyRules typeSubst rules typeTerms) $ \typeTerms' -> do
+        for_ (applyRules typeSubst rules typeTerms) $ \(_rule, typeTerms') -> do
           -- C a' b' c'
           let types' = fmap fromTypeTerm typeTerms'
           let predType' = fromDecomposeConstraint types'

--- a/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
+++ b/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor, LambdaCase, RecordWildCards, ViewPatterns #-}
+{-# LANGUAGE DeriveFunctor, DeriveFoldable, DeriveTraversable, LambdaCase, RecordWildCards, ViewPatterns #-}
 module TypeLevel.Rewrite.Internal.DecomposedConstraint where
 
 import Control.Applicative
@@ -12,7 +12,7 @@ import Predicate (EqRel(NomEq), Pred(ClassPred, EqPred), classifyPredType, mkCla
 data DecomposedConstraint a
   = EqualityConstraint a a        -- lhs ~ rhs
   | InstanceConstraint Class [a]  -- C a b c
-  deriving Functor
+  deriving (Functor, Foldable, Traversable)
 
 asEqualityConstraint
   :: Ct

--- a/src/TypeLevel/Rewrite/Internal/TypeNode.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeNode.hs
@@ -3,7 +3,7 @@ module TypeLevel.Rewrite.Internal.TypeNode where
 
 -- GHC API
 import TyCon (TyCon)
-import Type (Type, isNumLitTy, isStrLitTy, splitTyConApp_maybe)
+import Type (Type, isNumLitTy, isStrLitTy, mkTyConApp, splitTyConApp_maybe)
 
 import TypeLevel.Rewrite.Internal.TypeEq
 
@@ -26,3 +26,10 @@ toTypeNodeApp_maybe tyLit@(isStrLitTy -> Just _)
   = pure (TyLit (TypeEq tyLit), [])
 toTypeNodeApp_maybe _
   = Nothing
+
+fromTypeNode
+  :: TypeNode
+  -> [Type]
+  -> Type
+fromTypeNode (TyCon tyCon) args = mkTyConApp tyCon args
+fromTypeNode (TyLit (TypeEq tyLit)) _ = tyLit

--- a/test/error-messages-cases/error-location/expected
+++ b/test/error-messages-cases/error-location/expected
@@ -1,6 +1,7 @@
 <path>/error-messages-cases/error-location/src/ErrorLocation/Test.hs:13:5: error:
     • No instance for (Foo (F a b)) arising from a use of ‘foo’
-    • In the expression: foo @(F a (F a b))
+    • From the typelevel rewrite rule: F x (F x y) ~ F x y
+      In the expression: foo @(F a (F a b))
       In an equation for ‘f’: f = foo @(F a (F a b))
    |
 13 | f = foo @(F a (F a b))

--- a/test/error-messages-cases/error-location/expected
+++ b/test/error-messages-cases/error-location/expected
@@ -1,2 +1,7 @@
 <path>/error-messages-cases/error-location/src/ErrorLocation/Test.hs:13:5: error:
     • No instance for (Foo (F a b)) arising from a use of ‘foo’
+    • In the expression: foo @(F a (F a b))
+      In an equation for ‘f’: f = foo @(F a (F a b))
+   |
+13 | f = foo @(F a (F a b))
+   |     ^^^^^^^^^^^^^^^^^^

--- a/test/error-messages-cases/error-location/expected
+++ b/test/error-messages-cases/error-location/expected
@@ -1,0 +1,2 @@
+<path>/error-messages-cases/error-location/src/ErrorLocation/Test.hs:13:5: error:
+    • No instance for (Foo (F a b)) arising from a use of ‘foo’

--- a/test/error-messages-cases/error-location/package.yaml
+++ b/test/error-messages-cases/error-location/package.yaml
@@ -1,0 +1,7 @@
+dependencies:
+  - base
+  - typelevel-rewrite-rules
+
+library:
+  source-dirs:      src
+  ghc-options: -W -Wall

--- a/test/error-messages-cases/error-location/src/ErrorLocation/Laws.hs
+++ b/test/error-messages-cases/error-location/src/ErrorLocation/Laws.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE ConstraintKinds, TypeFamilies #-}
+module ErrorLocation.Laws where
+
+type family F a b
+
+type FLaw a b = F a (F a b) ~ F a b

--- a/test/error-messages-cases/error-location/src/ErrorLocation/Laws.hs
+++ b/test/error-messages-cases/error-location/src/ErrorLocation/Laws.hs
@@ -3,4 +3,4 @@ module ErrorLocation.Laws where
 
 type family F a b
 
-type FLaw a b = F a (F a b) ~ F a b
+type FLaw x y = F x (F x y) ~ F x y

--- a/test/error-messages-cases/error-location/src/ErrorLocation/Test.hs
+++ b/test/error-messages-cases/error-location/src/ErrorLocation/Test.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE AllowAmbiguousTypes, FlexibleContexts, ScopedTypeVariables, TypeApplications, TypeFamilies #-}
+{-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
+                -fplugin-opt=TypeLevel.Rewrite:ErrorLocation.Laws.FLaw #-}
+module ErrorLocation.Test where
+
+import ErrorLocation.Laws
+
+
+class Foo a where
+  foo :: ()
+
+f :: forall a b. ()
+f = foo @(F a (F a b))

--- a/test/error-messages/Test.hs
+++ b/test/error-messages/Test.hs
@@ -124,10 +124,19 @@ main = do
                                      in pre <> "0.0.0-<hash>" <> cleanHashes post
                                 else t
 
+                -- "/Users/gelisam/working/haskell/typelevel-rewrite-rules/test/error-messages-cases/" -> "<path>/error-message-cases/"
+                cleanPaths :: Text -> Text
+                cleanPaths t = if "/error-messages-cases/" `Text.isInfixOf` t
+                                then let (prePath, post) = Text.breakOn "/error-messages-cases/" t
+                                         pre = Text.unwords $ init $ Text.words prePath
+                                     in pre <> " <path>" <> post
+                                else t
+
                 actualLines :: [Text]
                 actualLines = List.mapMaybe stripCasePrefix
                             . fmap cleanHashes
                             . fmap cleanLine
+                            . fmap cleanPaths
                             . Text.lines
                             $ actualOutput
 

--- a/test/should-compile/Data/Vinyl/TypeLevel/Test.hs
+++ b/test/should-compile/Data/Vinyl/TypeLevel/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds, RankNTypes, TypeFamilies, TypeOperators #-}
-{-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10
+                -fplugin TypeLevel.Rewrite
                 -fplugin-opt=TypeLevel.Rewrite:Data.Vinyl.TypeLevel.RewriteRules.RightIdentity
                 -fplugin-opt=TypeLevel.Rewrite:Data.Vinyl.TypeLevel.RewriteRules.RightAssociative #-}
 module Data.Vinyl.TypeLevel.Test where

--- a/test/should-compile/MonoKinds/Test.hs
+++ b/test/should-compile/MonoKinds/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds, RankNTypes, TypeFamilies, TypeOperators #-}
-{-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10
+                -fplugin TypeLevel.Rewrite
                 -fplugin-opt=TypeLevel.Rewrite:MonoKinds.Append.RightIdentity
                 -fplugin-opt=TypeLevel.Rewrite:MonoKinds.Append.RightAssociative #-}
 module MonoKinds.Test where

--- a/test/should-compile/SamePackage/Test.hs
+++ b/test/should-compile/SamePackage/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds, RankNTypes, TypeFamilies, TypeOperators #-}
-{-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10
+                -fplugin TypeLevel.Rewrite
                 -fplugin-opt=TypeLevel.Rewrite:SamePackage.Append.RightIdentity
                 -fplugin-opt=TypeLevel.Rewrite:SamePackage.Append.RightAssociative #-}
 module SamePackage.Test where

--- a/test/should-compile/TypeLevel/Append/Test.hs
+++ b/test/should-compile/TypeLevel/Append/Test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds, RankNTypes, ScopedTypeVariables, TypeFamilies, TypeOperators #-}
-{-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10
+                -fplugin TypeLevel.Rewrite
                 -fplugin-opt=TypeLevel.Rewrite:TypeLevel.Append.RightIdentity
                 -fplugin-opt=TypeLevel.Rewrite:TypeLevel.Append.RightAssociative #-}
 module TypeLevel.Append.Test where


### PR DESCRIPTION
fixes #17, so the error messages involving rewritten constraints now point to the original constraint instead of pointing nowhere. Even better, the error message's context stack now explains how the rewritten constraint was obtained by including the rewrite rule(s) which fired:

```
<path>/error-messages-cases/error-location/src/ErrorLocation/Test.hs:13:5: error:
    • No instance for (Foo (F a b)) arising from a use of ‘foo’
    • From the typelevel rewrite rule: F x (F x y) ~ F x y
      In the expression: foo @(F a (F a b))
      In an equation for ‘f’: f = foo @(F a (F a b))
   |
13 | f = foo @(F a (F a b))
   |     ^^^^^^^^^^^^^^^^^^
```

One big consequence of this change is that each time we apply a rewrite rule, we increment ghc's iteration count instead of our own. Users are thus a lot more likely to get an error about ghc's iteration count if their types are relatively complicated, as ghc's iteration limit is much lower than ours.

On the down side, if the user's rewrite rules form a cycle, they will no longer get our custom `rewrite rules form a cycle` error message, they will instead get an error about increasing ghc's iteration count.

On the plus side, if the user's code requires a lot of rewrite rules to be applied, they will no longer get a spurious `rewrite rules form a cycle` error message even though their rules are not actually cyclic. Better: they are now able to get around the problem by increasing ghc's iteration count.
