### PR TITLE
ghc-9.0 is not yet supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,10 @@ jobs:
           # Check that our upper bounds are correct by building with the latest
           # version of everything. We use cabal because it uses the latest
           # versions of our dependencies allowed by our upper bounds.
+          #
+          # TODO: switch back to "ghc: latest" once we support ghc-9.0
           - name: newest
-            ghc: latest
+            ghc: "8.10"
             os: ubuntu-latest
 
     steps:

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
 library:
   source-dirs:      src
   dependencies:
-    - ghc >= 8.10.2
+    - ghc >= 8.10.2 && < 9.0
     - containers >= 0.6.2.1
     - term-rewriting >= 0.3.0.1
     - transformers >= 0.5.6.2

--- a/typelevel-rewrite-rules.cabal
+++ b/typelevel-rewrite-rules.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a1ac726a788c1f338883b84c965693f9ad6e08e6061ca02afc499aa921710045
+-- hash: 2673197ba6a9e92128e851017519e221b95a23ca70b1f7b84158feae74eba11b
 
 name:           typelevel-rewrite-rules
 version:        1.0
@@ -48,7 +48,7 @@ library
   build-depends:
       base >=4.12 && <5
     , containers >=0.6.2.1
-    , ghc >=8.10.2
+    , ghc >=8.10.2 && <9.0
     , ghc-prim >=0.5.3
     , term-rewriting >=0.3.0.1
     , transformers >=0.5.6.2


### PR DESCRIPTION
so we need to add upper bounds so that cabal doesn't think we do support ghc-9.0