### PR TITLE
Support for ghc-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: "8.10"
-            os: ubuntu-latest
           - ghc: "9.0"
             os: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,11 @@ jobs:
           # versions of our dependencies allowed by our upper bounds.
           #
           # TODO: switch back to "ghc: latest" once we support ghc-9.0
-          - name: newest
+          - name: oldest
             ghc: "8.10"
+            os: ubuntu-latest
+          - name: newest
+            ghc: "9.0"
             os: ubuntu-latest
 
     steps:
@@ -119,6 +122,8 @@ jobs:
       matrix:
         include:
           - ghc: "8.10"
+            os: ubuntu-latest
+          - ghc: "9.0"
             os: ubuntu-latest
 
     steps:

--- a/oldest-supported-lts.yaml
+++ b/oldest-supported-lts.yaml
@@ -1,7 +1,7 @@
 # if this build fails and you need to bump the lts, remember
 # to also bump the lower bounds in package.yaml to match the
 # versions provided by that new lts!
-resolver: nightly-2020-12-10
+resolver: lts-18.3
 packages:
 - '.'
 

--- a/oldest-supported-lts.yaml
+++ b/oldest-supported-lts.yaml
@@ -1,7 +1,7 @@
 # if this build fails and you need to bump the lts, remember
 # to also bump the lower bounds in package.yaml to match the
 # versions provided by that new lts!
-resolver: lts-18.3
+resolver: nightly-2020-12-10
 packages:
 - '.'
 

--- a/package.yaml
+++ b/package.yaml
@@ -25,10 +25,11 @@ dependencies:
 library:
   source-dirs:      src
   dependencies:
-    - ghc >= 8.10.2 && < 9.0
+    - ghc >= 8.10.2 && <= 9.1
     - containers >= 0.6.2.1
     - term-rewriting >= 0.3.0.1
     - transformers >= 0.5.6.2
+  default-extensions:  CPP
 
 tests:
   should-compile:

--- a/package.yaml
+++ b/package.yaml
@@ -25,7 +25,7 @@ dependencies:
 library:
   source-dirs:      src
   dependencies:
-    - ghc >= 8.10.2 && <= 9.1
+    - ghc >= 8.10.2 && <9.1
     - containers >= 0.6.2.1
     - term-rewriting >= 0.3.0.1
     - transformers >= 0.5.6.2

--- a/src/TypeLevel/Rewrite.hs
+++ b/src/TypeLevel/Rewrite.hs
@@ -8,6 +8,7 @@ import Data.Foldable
 import Data.Traversable
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Core.Coercion (Role(Representational), mkUnivCo)
 import GHC.Tc.Types.Constraint (CtEvidence(ctev_loc), Ct, ctEvExpr, ctLoc, mkNonCanonical)
 import GHC.Plugins (PredType, SDoc, eqType, fsep, ppr)
@@ -17,6 +18,17 @@ import GHC.Tc.Plugin (newWanted)
 import GHC.Core.TyCo.Rep (UnivCoProvenance(PluginProv))
 import GHC.Plugins (synTyConDefn_maybe)
 import GHC.Tc.Types (TcPluginResult(..), TcPluginM, ErrCtxt, pushErrCtxtSameOrigin, TcPlugin(..))
+#else
+import Coercion (Role(Representational), mkUnivCo)
+import Constraint (CtEvidence(ctev_loc), Ct, ctEvExpr, ctLoc, mkNonCanonical)
+import GhcPlugins (PredType, SDoc, eqType, fsep, ppr)
+import Plugins (Plugin(pluginRecompile, tcPlugin), CommandLineOption, defaultPlugin, purePlugin)
+import TcEvidence (EvExpr, EvTerm, evCast)
+import TcPluginM (newWanted)
+import TcRnTypes
+import TyCoRep (UnivCoProvenance(PluginProv))
+import TyCon (synTyConDefn_maybe)
+#endif
 
 import TypeLevel.Rewrite.Internal.ApplyRules
 import TypeLevel.Rewrite.Internal.DecomposedConstraint

--- a/src/TypeLevel/Rewrite.hs
+++ b/src/TypeLevel/Rewrite.hs
@@ -8,15 +8,15 @@ import Data.Foldable
 import Data.Traversable
 
 -- GHC API
-import Coercion (Role(Representational), mkUnivCo)
-import Constraint (CtEvidence(ctev_loc), Ct, ctEvExpr, ctLoc, mkNonCanonical)
-import GhcPlugins (PredType, SDoc, eqType, fsep, ppr)
-import Plugins (Plugin(pluginRecompile, tcPlugin), CommandLineOption, defaultPlugin, purePlugin)
-import TcEvidence (EvExpr, EvTerm, evCast)
-import TcPluginM (newWanted)
-import TcRnTypes
-import TyCoRep (UnivCoProvenance(PluginProv))
-import TyCon (synTyConDefn_maybe)
+import GHC.Core.Coercion (Role(Representational), mkUnivCo)
+import GHC.Tc.Types.Constraint (CtEvidence(ctev_loc), Ct, ctEvExpr, ctLoc, mkNonCanonical)
+import GHC.Plugins (PredType, SDoc, eqType, fsep, ppr)
+import GHC.Plugins (Plugin(pluginRecompile, tcPlugin), CommandLineOption, defaultPlugin, purePlugin)
+import GHC.Tc.Types.Evidence (EvExpr, EvTerm, evCast)
+import GHC.Tc.Plugin (newWanted)
+import GHC.Core.TyCo.Rep (UnivCoProvenance(PluginProv))
+import GHC.Plugins (synTyConDefn_maybe)
+import GHC.Tc.Types (TcPluginResult(..), TcPluginM, ErrCtxt, pushErrCtxtSameOrigin, TcPlugin(..))
 
 import TypeLevel.Rewrite.Internal.ApplyRules
 import TypeLevel.Rewrite.Internal.DecomposedConstraint

--- a/src/TypeLevel/Rewrite/Internal/ApplyRules.hs
+++ b/src/TypeLevel/Rewrite/Internal/ApplyRules.hs
@@ -13,7 +13,11 @@ import Data.Traversable
 import qualified Data.Map as Map
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Plugins (TyVar)
+#else
+import Type (TyVar)
+#endif
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/ApplyRules.hs
+++ b/src/TypeLevel/Rewrite/Internal/ApplyRules.hs
@@ -13,7 +13,7 @@ import Data.Traversable
 import qualified Data.Map as Map
 
 -- GHC API
-import Type (TyVar)
+import GHC.Plugins (TyVar)
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
+++ b/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
@@ -5,8 +5,8 @@ import Control.Applicative
 
 -- GHC API
 import GHC (Class, Type)
-import Constraint (Ct, ctEvPred, ctEvidence)
-import Predicate (EqRel(NomEq), Pred(ClassPred, EqPred), classifyPredType, mkClassPred, mkPrimEqPred)
+import GHC.Tc.Types.Constraint (Ct, ctEvPred, ctEvidence)
+import GHC.Core.Predicate (EqRel(NomEq), Pred(ClassPred, EqPred), classifyPredType, mkClassPred, mkPrimEqPred)
 
 
 data DecomposedConstraint a

--- a/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
+++ b/src/TypeLevel/Rewrite/Internal/DecomposedConstraint.hs
@@ -5,8 +5,13 @@ import Control.Applicative
 
 -- GHC API
 import GHC (Class, Type)
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Tc.Types.Constraint (Ct, ctEvPred, ctEvidence)
 import GHC.Core.Predicate (EqRel(NomEq), Pred(ClassPred, EqPred), classifyPredType, mkClassPred, mkPrimEqPred)
+#else
+import Constraint (Ct, ctEvPred, ctEvidence)
+import Predicate (EqRel(NomEq), Pred(ClassPred, EqPred), classifyPredType, mkClassPred, mkPrimEqPred)
+#endif
 
 
 data DecomposedConstraint a

--- a/src/TypeLevel/Rewrite/Internal/Lookup.hs
+++ b/src/TypeLevel/Rewrite/Internal/Lookup.hs
@@ -5,16 +5,16 @@ import Control.Arrow ((***), first)
 import Data.Tuple (swap)
 
 -- GHC API
-import Finder (cannotFindModule)
+import GHC.Driver.Finder (cannotFindModule)
 import GHC (DataCon, TyCon, dataConTyCon)
-import Module (Module, ModuleName, mkModuleName)
-import OccName (mkDataOcc, mkTcOcc)
-import Panic (panicDoc)
-import TcPluginM
+import GHC (Module, ModuleName, mkModuleName)
+import GHC.Plugins (mkDataOcc, mkTcOcc)
+import GHC.Utils.Panic (panicDoc)
+import GHC.Tc.Plugin
   ( FindResult(Found), TcPluginM, findImportedModule, lookupOrig, tcLookupDataCon, tcLookupTyCon
   , unsafeTcPluginTcM
   )
-import TcSMonad (getDynFlags)
+import GHC.Tc.Solver.Monad (getDynFlags)
 
 
 lookupModule

--- a/src/TypeLevel/Rewrite/Internal/Lookup.hs
+++ b/src/TypeLevel/Rewrite/Internal/Lookup.hs
@@ -5,8 +5,9 @@ import Control.Arrow ((***), first)
 import Data.Tuple (swap)
 
 -- GHC API
-import GHC.Driver.Finder (cannotFindModule)
 import GHC (DataCon, TyCon, dataConTyCon)
+#if MIN_VERSION_ghc(9,0,0)
+import GHC.Driver.Finder (cannotFindModule)
 import GHC (Module, ModuleName, mkModuleName)
 import GHC.Plugins (mkDataOcc, mkTcOcc)
 import GHC.Utils.Panic (panicDoc)
@@ -15,7 +16,14 @@ import GHC.Tc.Plugin
   , unsafeTcPluginTcM
   )
 import GHC.Tc.Solver.Monad (getDynFlags)
-
+#else
+import Finder (cannotFindModule)
+import Module (Module, ModuleName, mkModuleName)
+import OccName (mkDataOcc, mkTcOcc)
+import Panic (panicDoc)
+import TcPluginM
+import TcSMonad (getDynFlags)
+#endif
 
 lookupModule
   :: String  -- ^ module name

--- a/src/TypeLevel/Rewrite/Internal/PrettyPrint.hs
+++ b/src/TypeLevel/Rewrite/Internal/PrettyPrint.hs
@@ -4,9 +4,9 @@ module TypeLevel.Rewrite.Internal.PrettyPrint where
 import Data.List (intercalate)
 
 -- GHC API
-import Outputable (ppr, showSDocUnsafe)
-import TyCon (TyCon)
-import Type (TyVar, Type)
+import GHC.Utils.Outputable (ppr, showSDocUnsafe)
+import GHC.Plugins (TyCon)
+import GHC.Plugins (TyVar, Type)
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/PrettyPrint.hs
+++ b/src/TypeLevel/Rewrite/Internal/PrettyPrint.hs
@@ -4,9 +4,15 @@ module TypeLevel.Rewrite.Internal.PrettyPrint where
 import Data.List (intercalate)
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Utils.Outputable (ppr, showSDocUnsafe)
 import GHC.Plugins (TyCon)
 import GHC.Plugins (TyVar, Type)
+#else
+import Outputable (ppr, showSDocUnsafe)
+import TyCon (TyCon)
+import Type (TyVar, Type)
+#endif
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/TypeEq.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeEq.hs
@@ -2,7 +2,11 @@ module TypeLevel.Rewrite.Internal.TypeEq where
 
 import Data.Function
 
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Plugins (Type, eqType)
+#else
+import GhcPlugins (Type, eqType)
+#endif
 
 
 -- | A newtype around 'Type' which has an 'Eq' instance.

--- a/src/TypeLevel/Rewrite/Internal/TypeEq.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeEq.hs
@@ -2,7 +2,7 @@ module TypeLevel.Rewrite.Internal.TypeEq where
 
 import Data.Function
 
-import GhcPlugins (Type, eqType)
+import GHC.Plugins (Type, eqType)
 
 
 -- | A newtype around 'Type' which has an 'Eq' instance.

--- a/src/TypeLevel/Rewrite/Internal/TypeNode.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeNode.hs
@@ -2,8 +2,8 @@
 module TypeLevel.Rewrite.Internal.TypeNode where
 
 -- GHC API
-import TyCon (TyCon)
-import Type (Type, isNumLitTy, isStrLitTy, mkTyConApp, splitTyConApp_maybe)
+import GHC (TyCon)
+import GHC.Plugins (Type, isNumLitTy, isStrLitTy, mkTyConApp, splitTyConApp_maybe)
 
 import TypeLevel.Rewrite.Internal.TypeEq
 

--- a/src/TypeLevel/Rewrite/Internal/TypeNode.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeNode.hs
@@ -2,8 +2,13 @@
 module TypeLevel.Rewrite.Internal.TypeNode where
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC (TyCon)
 import GHC.Plugins (Type, isNumLitTy, isStrLitTy, mkTyConApp, splitTyConApp_maybe)
+#else
+import TyCon (TyCon)
+import Type (Type, isNumLitTy, isStrLitTy, mkTyConApp, splitTyConApp_maybe)
+#endif
 
 import TypeLevel.Rewrite.Internal.TypeEq
 

--- a/src/TypeLevel/Rewrite/Internal/TypeRule.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeRule.hs
@@ -3,9 +3,9 @@
 module TypeLevel.Rewrite.Internal.TypeRule where
 
 -- GHC API
-import Name (getOccString)
-import Predicate (mkPrimEqPred)
-import Type (TyVar, Type, mkTyVarTy)
+import GHC.Plugins (getOccString)
+import GHC.Core.Predicate (mkPrimEqPred)
+import GHC.Plugins (TyVar, Type, mkTyVarTy)
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/TypeRule.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeRule.hs
@@ -3,9 +3,15 @@
 module TypeLevel.Rewrite.Internal.TypeRule where
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Plugins (getOccString)
 import GHC.Core.Predicate (mkPrimEqPred)
 import GHC.Plugins (TyVar, Type, mkTyVarTy)
+#else
+import Name (getOccString)
+import Predicate (mkPrimEqPred)
+import Type (TyVar, Type, mkTyVarTy)
+#endif
 
 -- term-rewriting API
 import Data.Rewriting.Rule (Rule(..))

--- a/src/TypeLevel/Rewrite/Internal/TypeTemplate.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeTemplate.hs
@@ -2,7 +2,7 @@
 module TypeLevel.Rewrite.Internal.TypeTemplate where
 
 -- GHC API
-import Type (TyVar, Type, getTyVar_maybe)
+import GHC.Plugins (TyVar, Type, getTyVar_maybe)
 
 -- term-rewriting API
 import Data.Rewriting.Term (Term(Fun, Var))

--- a/src/TypeLevel/Rewrite/Internal/TypeTemplate.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeTemplate.hs
@@ -2,7 +2,11 @@
 module TypeLevel.Rewrite.Internal.TypeTemplate where
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Plugins (TyVar, Type, getTyVar_maybe)
+#else
+import Type (TyVar, Type, getTyVar_maybe)
+#endif
 
 -- term-rewriting API
 import Data.Rewriting.Term (Term(Fun, Var))

--- a/src/TypeLevel/Rewrite/Internal/TypeTerm.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeTerm.hs
@@ -2,7 +2,11 @@
 module TypeLevel.Rewrite.Internal.TypeTerm where
 
 -- GHC API
+#if MIN_VERSION_ghc(9,0,0)
 import GHC.Plugins (Type, mkTyConApp)
+#else
+import Type (Type, mkTyConApp)
+#endif
 
 -- term-rewriting API
 import Data.Rewriting.Term (Term(Fun, Var))

--- a/src/TypeLevel/Rewrite/Internal/TypeTerm.hs
+++ b/src/TypeLevel/Rewrite/Internal/TypeTerm.hs
@@ -2,7 +2,7 @@
 module TypeLevel.Rewrite.Internal.TypeTerm where
 
 -- GHC API
-import Type (Type, mkTyConApp)
+import GHC.Plugins (Type, mkTyConApp)
 
 -- term-rewriting API
 import Data.Rewriting.Term (Term(Fun, Var))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: nightly-2020-12-10
+resolver: nightly-2021-07-22
 packages:
 - '.'
 
 extra-deps:
 - term-rewriting-0.4.0.2
-- union-find-array-0.1.0.2
+- union-find-array-0.1.0.3

--- a/test/error-messages-cases/no-plugin/expected
+++ b/test/error-messages-cases/no-plugin/expected
@@ -1,1 +1,26 @@
-    • Couldn't match type ‘as ++ (bs ++ cs)’ with ‘(as ++ bs) ++ cs’
+configure (lib)
+Configuring no-plugin-0.0.0...
+build (lib)
+Preprocessing library for no-plugin-0.0.0..
+Building library for no-plugin-0.0.0..
+[1 of 2] Compiling NoPlugin.Test
+
+<path>/error-messages-cases/no-plugin/src/NoPlugin/Test.hs:15:16: error:
+    • Couldn't match type: as ++ (bs ++ cs)
+                     with: (as ++ bs) ++ cs
+      Expected: proxy ((as ++ bs) ++ cs)
+        Actual: proxy (as ++ (bs ++ cs))
+      NB: ‘++’ is a non-injective type family
+    • In the expression: r
+      In an equation for ‘ex2e’: ex2e _ _ _ r = r
+    • Relevant bindings include
+        r :: proxy (as ++ (bs ++ cs)) (bound at src/NoPlugin/Test.hs:15:12)
+        ex2e :: proxy as
+                -> proxy bs
+                -> proxy cs
+                -> proxy (as ++ (bs ++ cs))
+                -> proxy ((as ++ bs) ++ cs)
+          (bound at src/NoPlugin/Test.hs:15:1)
+   |
+15 | ex2e _ _ _ r = r
+   |                ^

--- a/test/should-compile/GHC/TypeLits/Test.hs
+++ b/test/should-compile/GHC/TypeLits/Test.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DataKinds, RankNTypes, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE DataKinds, RankNTypes, TypeFamilies, TypeOperators, AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -fplugin TypeLevel.Rewrite
                 -fplugin-opt=TypeLevel.Rewrite:GHC.TypeLits.RewriteRules.NatRule
                 -fplugin-opt=TypeLevel.Rewrite:GHC.TypeLits.RewriteRules.SymbolRule #-}

--- a/typelevel-rewrite-rules.cabal
+++ b/typelevel-rewrite-rules.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2673197ba6a9e92128e851017519e221b95a23ca70b1f7b84158feae74eba11b
+-- hash: 201dd297be3e249f9d5773e714652b18086e8f3160a1bdca783242cb52598513
 
 name:           typelevel-rewrite-rules
 version:        1.0
@@ -53,7 +53,8 @@ library
     , term-rewriting >=0.3.0.1
     , transformers >=0.5.6.2
   default-language: Haskell2010
-  default-extensions:  CPP
+  default-extensions:
+      CPP
 
 test-suite should-compile
   type: exitcode-stdio-1.0

--- a/typelevel-rewrite-rules.cabal
+++ b/typelevel-rewrite-rules.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
       base >=4.12 && <5
     , containers >=0.6.2.1
-    , ghc >=8.10.2 && <9.0
+    , ghc >=8.10.2 && <= 9.1
     , ghc-prim >=0.5.3
     , term-rewriting >=0.3.0.1
     , transformers >=0.5.6.2

--- a/typelevel-rewrite-rules.cabal
+++ b/typelevel-rewrite-rules.cabal
@@ -53,6 +53,7 @@ library
     , term-rewriting >=0.3.0.1
     , transformers >=0.5.6.2
   default-language: Haskell2010
+  default-extensions:  CPP
 
 test-suite should-compile
   type: exitcode-stdio-1.0

--- a/typelevel-rewrite-rules.cabal
+++ b/typelevel-rewrite-rules.cabal
@@ -48,7 +48,7 @@ library
   build-depends:
       base >=4.12 && <5
     , containers >=0.6.2.1
-    , ghc >=8.10.2 && <= 9.1
+    , ghc >=8.10.2 && <9.1
     , ghc-prim >=0.5.3
     , term-rewriting >=0.3.0.1
     , transformers >=0.5.6.2


### PR DESCRIPTION
We can test this pr with ghc-9, but it breaks backwards compatibility, so I will add `ifdef` of `CPP`-extenstion.